### PR TITLE
Added ability to select search type for users/attributes

### DIFF
--- a/voicer-client/src/components/voice/AttributeForm.jsx
+++ b/voicer-client/src/components/voice/AttributeForm.jsx
@@ -8,7 +8,6 @@ const AttributeForm = () => {
 
   const { refreshAppHandler, url } = useContext(DataContext)
 
-
   const makeTag = (e) => {
     if (e.key === "Enter") {
       setTags([...tags, e.target.value])
@@ -23,15 +22,17 @@ const AttributeForm = () => {
   const handleSubmit = (e) => {
     e.preventDefault()
     console.log(tags)
-    axios
-      .post(`${url}/api/attribute`, tags)
-      .then((res) => {
-        console.log(res)
-        refreshAppHandler()
-      })
-      .catch((err) => {
-        console.log(err)
-      })
+    tags.forEach((tag) => {
+      axios
+        // { id: 2, tags: [cool, great] }
+        .post(`${url}/api/attribute`, tag)
+        .then((res) => {
+          console.log(res)
+        })
+        .catch((err) => {
+          console.log(err)
+        })
+    })
   }
 
   return (

--- a/voicer-client/src/components/voice/Voice.jsx
+++ b/voicer-client/src/components/voice/Voice.jsx
@@ -9,6 +9,7 @@ export default function Voice() {
   const [data, setData] = useState([])
   const [voiceSearch, setVoiceSearch] = useState("")
   const [searchTags, setSearchTags] = useState("")
+  const [strict, setStrict] = useState(true)
 
   const { token, url } = useContext(DataContext)
 
@@ -51,8 +52,9 @@ export default function Voice() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchTags])
 
-  useEffect(()=> {
-      setSearchTags(`?tag=${voiceSearch.split(' ')}`)
+  useEffect(() => {
+    setSearchTags(`?tag=${voiceSearch.split(" ")}&strict=${strict}`)
+    console.log(searchTags)
   }, [voiceSearch])
 
   return (
@@ -84,6 +86,31 @@ export default function Voice() {
               setVoiceSearch(e.target.value)
             }}
           />
+          <div>
+            <input
+              type="radio"
+              name="search"
+              value="strict"
+              checked
+              onClick={() => {
+                setStrict(true)
+              }}
+            />
+            <label htmlFor="strict">Strict Search</label>
+          </div>
+
+          <div>
+            <input
+              type="radio"
+              name="search"
+              value="expansive"
+              onClick={() => {
+                setStrict(false)
+              }}
+            />
+            <label htmlFor="expansive">Expansive Search</label>
+          </div>
+
           {data.map((voice) => (
             <a key={voice.display_name} href={`/voice/${voice.display_name}`}>
               <VoiceItem data={voice} />


### PR DESCRIPTION
Added a radio button that let's users select whether they want
a "strict" search (i.e. all terms have to match exactly) or a
"expansive" search result which includes all results that include
one of the keywords.

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] My code has been reviewed by at least one peer
- [x ] My changes generate no new warnings
- [ x] There are no merge conflicts
